### PR TITLE
Use raw ARN to avoid cyclic dependency

### DIFF
--- a/lib/serverless-sns-sqs-lambda.js
+++ b/lib/serverless-sns-sqs-lambda.js
@@ -302,7 +302,7 @@ Usage
    * @param {object} template the template which gets mutated
    * @param {{name}} config the name of the queue the lambda is subscribed to
    */
-  addLambdaSqsPermissions(template, { name }) {
+  addLambdaSqsPermissions(template, { name, prefix }) {
     template.Resources.IamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement.push(
       {
         Effect: "Allow",
@@ -312,9 +312,8 @@ Usage
           "sqs:GetQueueAttributes"
         ],
         Resource: [
-          {
-            "Fn::GetAtt": [`${name}Queue`, "Arn"]
-          }
+          `arn:aws:sqs:#{AWS::Region}:#{AWS::AccountId}:${prefix}${name}Queue`,
+          `arn:aws:sqs:#{AWS::Region}:#{AWS::AccountId}:${prefix}${name}DeadLetterQueue`
         ]
       }
     );


### PR DESCRIPTION
* Use raw ARNs to avoid CloudFormation cyclic dependency.
* Add permissions to the DLQ so consumers of this serverless plugin don't have to.