### PR TITLE
feat: add `deadLetterMessageRetentionPeriodSeconds` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ functions:
           maxRetryCount: 2 # Optional - default value is 5
           kmsMasterKeyId: alias/aws/sqs # optional - default is none (no encryption)
           kmsDataKeyReusePeriodSeconds: 600 # optional - AWS default is 300 seconds
+          deadLetterMessageRetentionPeriodSeconds: 1209600 # optional - AWS default is 345600 secs (4 days)
           rawMessageDelivery: true # Optional - default value is true
           filterPolicy: # Optional - filter messages that are handled
             pets:

--- a/lib/__snapshots__/serverless-sns-sqs-lambda.test.ts.snap
+++ b/lib/__snapshots__/serverless-sns-sqs-lambda.test.ts.snap
@@ -7,6 +7,7 @@ Object {
       "Properties": Object {
         "KmsDataKeyReusePeriodSeconds": 200,
         "KmsMasterKeyId": "some key",
+        "MessageRetentionPeriod": 1209600,
         "QueueName": "some prefixsome nameDeadLetterQueue",
       },
       "Type": "AWS::SQS::Queue",

--- a/lib/serverless-sns-sqs-lambda.test.ts
+++ b/lib/serverless-sns-sqs-lambda.test.ts
@@ -90,6 +90,7 @@ describe("Test Serverless SNS SQS Lambda", () => {
         maxRetryCount: 4,
         kmsMasterKeyId: "some key",
         kmsDataKeyReusePeriodSeconds: 200,
+        deadLetterMessageRetentionPeriodSeconds: 1209600,
         visibilityTimeout: 999,
         rawMessageDelivery: true,
         filterPolicy: { pet: ["dog", "cat"] }


### PR DESCRIPTION
This is a useful addition for the deadletter queue, because it helps in debugging.