### PR TITLE
build: add an action to auto approve dependabot PRs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,12 @@
+name: Auto Approve Dependabot PRs
+
+on: pull_request_target
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hmarr/auto-approve-action@v2.0.0
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+        with:
+          github-token: "${{ secrets.GH_TOKEN }}"


### PR DESCRIPTION
- Should save some time having to go through all the PRs and approve/merge them